### PR TITLE
Fix radio station icons in menu

### DIFF
--- a/main.c
+++ b/main.c
@@ -380,6 +380,10 @@ void PatchLCS(u32 text_addr) {
   _sw(0x34040000 | 480, text_addr + 0x002DB7A8);
   _sw(0x34040000 | 480, text_addr + 0x002DB858);
 
+  // Fix radio station icons in menu
+  _sw(0x34040000 | 480, text_addr + 0x002dedbc);
+  _sw(0x34040000 | 480, text_addr + 0x002df0b4);
+
   // Fix map scissoring
   _sw(0x24E7FFA0, text_addr + 0x002DB808);
   _sw(0x24E7FFA0, text_addr + 0x002DB8B8);


### PR DESCRIPTION
This PR fixes placement of radio station icons in Audio menu. They are now properly centered, whereas before half of them were cut off on the right side of the screen.

![2019-03-30-192144](https://user-images.githubusercontent.com/7947461/55280160-cd9aa100-5321-11e9-88ba-cfb3e8829c23.png)
