### PR TITLE
Fix pager in VCS

### DIFF
--- a/main.c
+++ b/main.c
@@ -269,6 +269,15 @@ void PatchVCS(u32 text_addr) {
   _sw(0x34040000 | 512, text_addr + 0x002A4400);
   _sw(0x34040000 | 320, text_addr + 0x002A4424);
 
+  // Fix pager proportions
+  _sw(0x34040000 | 512, text_addr + 0x001b8974);
+  _sw(0x34040000 | 512, text_addr + 0x001b89e4);
+  _sw(0x34040000 | 320, text_addr + 0x001b89f8);
+
+  // Fix pager text placement
+  _sw(0x34040000 | 512, text_addr + 0x001b8b40);
+  _sw(0x34050000 | 320, text_addr + 0x001b8b44);
+
   // Fix reflection
   _sh(PIXELFORMAT, text_addr + 0x00277EBC);
   _sh(PITCH, text_addr + 0x00277F2C);
@@ -292,7 +301,7 @@ void PatchVCS(u32 text_addr) {
   MAKE_CALL(text_addr + 0x002030D4, sceKernelGetSystemTimeWidePatched);
 
   // Cap to 20FPS
-  _sh(3, text_addr + 0x002030B4);
+  // _sh(3, text_addr + 0x002030B4);
 }
 
 // ULUS10041


### PR DESCRIPTION
This PR fixes pager proportions in VCS. It appears like the code assumes a 1:1.6 aspect ratio (due to rendering being 512x320 originally) and 16:9 ratio of Vita resolution broke it, so pager appeared squashed.

It also removes a 20FPS cap added to VCS.

![2019-03-31-220444](https://user-images.githubusercontent.com/7947461/55294518-62290000-5403-11e9-97f0-4027d498da55.png)
